### PR TITLE
Update golangci-lint pre-commit hook version to resolve module issues

### DIFF
--- a/linkfiles/.pre-commit-config.yaml
+++ b/linkfiles/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
           - --hook-config=--create-file-if-not-exist=true
           - --args=--sort=false
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.52.2
+    rev: v1.55.2
     hooks:
       - id: golangci-lint
         name: golangci-lint


### PR DESCRIPTION
Version update appears to fix the following error that has cropped up recently:

> ERRO Running error: context loading failed: failed to load packages: failed to load with go/packages: err: exit status 1: stderr: package unsafe is not in GOROOT (/Users/<your user>/.cache/pre-commit/repo_<random>/golangenv-default/.go/src/unsafe)