### PR TITLE
Update Makefile targets to run plan/conftest/regula against examples

### DIFF
--- a/tasks/modules/Makefile
+++ b/tasks/modules/Makefile
@@ -114,15 +114,15 @@ tfmodule/list :
 
 .PHONY: tfmodule/plan
 tfmodule/plan : tfmodule/init
-	@$(foreach module,$(ALL_TF_MODULES),$(call plan_terraform_module,$(module)))
+	@$(foreach module,$(ALL_EXAMPLES),$(call plan_terraform_module,$(module)))
 
 .PHONY: tfmodule/test/regula
 tfmodule/test/regula : 
-	@$(foreach module,$(ALL_TF_MODULES),$(call regula_terraform_module,$(module)))
+	@$(foreach module,$(ALL_EXAMPLES),$(call regula_terraform_module,$(module)))
 
 .PHONY: tfmodule/test/conftest
 tfmodule/test/conftest : 
-	@$(foreach module,$(ALL_TF_MODULES),$(call conftest_terraform_module,$(module)))
+	@$(foreach module,$(ALL_EXAMPLES),$(call conftest_terraform_module,$(module)))
 
 .PHONY: tfmodule/pre_deploy_test
 tfmodule/pre_deploy_test : tfmodule/clone_custom_rules


### PR DESCRIPTION
Adding test.tfvars to the root of every repository isn't an acceptable solution, because TF modules may have required variables without default values. Examples should fully implement the root-level module and are a much cleaner solution; if you can plan/conftest/regula your example, you've run plan/conftest/regula against the root module and more.