### PR TITLE
Fix/make check

### DIFF
--- a/linkfiles/.pre-commit-config.yaml
+++ b/linkfiles/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
           - --hook-config=--create-file-if-not-exist=true
           - --args=--sort=false
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.52.2
+    rev: v1.55.2
     hooks:
       - id: golangci-lint
         name: golangci-lint

--- a/tasks/golang/Makefile
+++ b/tasks/golang/Makefile
@@ -59,7 +59,7 @@ go/readonly_test:
 # https://www.gnu.org/software/make/manual/html_node/Double_002dColon.html
 # "check" is a GNU Make pattern that runs tests on configured software
 .PHONY: check
-check::
+check:: tfmodule/plan
 ifeq ($(DISABLE_MAKE_CHECK_LINT),false)
 	$(MAKE) go/lint
 else

--- a/tasks/modules/Makefile
+++ b/tasks/modules/Makefile
@@ -63,7 +63,7 @@ define list_examples
 endef
 
 define combined_provider
-provider \"aws\" {\n\tregion  = \"us-east-2\"\n\tprofile = \"launch-admin\"\n}\n\nprovider \"azurerm\" {\n\tskip_provider_registration = true\n\tfeatures {\n\t\tresource_group {\n\t\tprevent_deletion_if_contains_resources = false\n\t\t}\n\t}\n}\n
+provider \"aws\" {\n  region  = \"us-east-2\"\n  profile = \"launch-admin\"\n}\n\nprovider \"azurerm\" {\n  skip_provider_registration = true\n  features {\n    resource_group {\n      prevent_deletion_if_contains_resources = false\n    }\n  }\n}\n
 endef
 
 define provider_file_path

--- a/tasks/modules/Makefile
+++ b/tasks/modules/Makefile
@@ -66,9 +66,13 @@ define combined_provider
 provider \"aws\" {\n\tregion  = \"us-east-2\"\n\tprofile = \"launch-admin\"\n}\n\nprovider \"azurerm\" {\n\tskip_provider_registration = true\n\tfeatures {\n\t\tresource_group {\n\t\tprevent_deletion_if_contains_resources = false\n\t\t}\n\t}\n}\n
 endef
 
+define provider_file_path
+$(1)/provider.tf
+endef
+
 define create_example_providers
-	echo $(1)
-	bash -c 'echo -e "$(combined_provider)"' > $(1)/provider.tf
+	$(eval PROVIDER_FILE_PATH:=$(call provider_file_path,$(1)))
+	[ -e $(PROVIDER_FILE_PATH) ] || bash -c 'echo -e "$(call combined_provider)"' > $(1)/provider.tf
 endef
 
 define plan_terraform_module

--- a/tasks/modules/Makefile
+++ b/tasks/modules/Makefile
@@ -42,8 +42,8 @@ endef
 
 define regula_terraform_module
 	echo && echo "Regula $(1) ...";
-	echo $(REGULA) run $(1)/terraform.tfplan.json --input-type tf-plan --severity $(REGULA_SEVERITY)
-	$(REGULA) run $(1)/terraform.tfplan.json --input-type tf-plan --severity $(REGULA_SEVERITY)
+	echo $(REGULA) run $(1)/terraform.tfplan.json --input-type tf-plan --severity $(REGULA_SEVERITY) --include components/policy/policy --include components/policy/waivers --include $(MODULE_DIR)/custom_policy/policy
+	$(REGULA) run $(1)/terraform.tfplan.json --input-type tf-plan --severity $(REGULA_SEVERITY) --include components/policy/policy --include components/policy/waivers --include $(MODULE_DIR)/custom_policy/policy
 
 endef
 

--- a/tasks/modules/Makefile
+++ b/tasks/modules/Makefile
@@ -19,6 +19,7 @@ VAR_FILE ?= test.tfvars
 # Temporary value until we can relocate policies and validate; will be defaulted
 # to 'high' in the future with the option to change this via .lcafenv
 REGULA_SEVERITY ?= off 
+CURRENT_DIR = $(notdir $(shell pwd))
 
 # Functions
 
@@ -62,8 +63,12 @@ define list_examples
 	$(FIND) ./examples -path "*/.terraform" -prune -o -name "main.tf" -not -path '*pipeline*' -exec dirname {} \; 2>/dev/null
 endef
 
-define combined_provider
-provider \"aws\" {\n  region  = \"us-east-2\"\n  profile = \"launch-admin\"\n}\n\nprovider \"azurerm\" {\n  skip_provider_registration = true\n  features {\n    resource_group {\n      prevent_deletion_if_contains_resources = false\n    }\n  }\n}\n
+define aws_provider
+provider \"aws\" {\n  region  = \"us-east-2\"\n  profile = \"launch-root-admin\"\n}\n
+endef
+
+define azurerm_provider
+provider \"azurerm\" {\n  skip_provider_registration = true\n  features {\n    resource_group {\n      prevent_deletion_if_contains_resources = false\n    }\n  }\n}\n
 endef
 
 define provider_file_path
@@ -72,7 +77,8 @@ endef
 
 define create_example_providers
 	$(eval PROVIDER_FILE_PATH:=$(call provider_file_path,$(1)))
-	[ -e $(PROVIDER_FILE_PATH) ] || bash -c 'echo -e "$(call combined_provider)"' > $(1)/provider.tf
+	$(if $(findstring aws,$(CURRENT_DIR)), [ -e $(PROVIDER_FILE_PATH) ] || bash -c 'echo -e "$(call aws_provider)"' > $(1)/provider.tf,)
+	$(if $(findstring azure,$(CURRENT_DIR)), [ -e $(PROVIDER_FILE_PATH) ] || bash -c 'echo -e "$(call azure_provider)"' > $(1)/provider.tf,)
 endef
 
 define plan_terraform_module

--- a/tasks/modules/Makefile
+++ b/tasks/modules/Makefile
@@ -62,6 +62,15 @@ define list_examples
 	$(FIND) ./examples -path "*/.terraform" -prune -o -name "main.tf" -not -path '*pipeline*' -exec dirname {} \; 2>/dev/null
 endef
 
+define combined_provider
+provider \"aws\" {\n\tregion  = \"us-east-2\"\n\tprofile = \"launch-admin\"\n}\n\nprovider \"azurerm\" {\n\tskip_provider_registration = true\n\tfeatures {\n\t\tresource_group {\n\t\tprevent_deletion_if_contains_resources = false\n\t\t}\n\t}\n}\n
+endef
+
+define create_example_providers
+	echo $(1)
+	bash -c 'echo -e "$(combined_provider)"' > $(1)/provider.tf
+endef
+
 define plan_terraform_module
 	echo && echo "Planning $(1) ...";
 	$(TERRAFORM) -chdir=$(1) plan -input=false -out=terraform.tfplan -var-file $(VAR_FILE);
@@ -98,12 +107,15 @@ tfmodule/fmt :
 .PHONY: tfmodule/init
 tfmodule/init :
 	@$(foreach module,$(ALL_TF_MODULES),$(call init_terraform_module,$(module)))
+	@$(foreach module,$(ALL_EXAMPLES),$(call init_terraform_module,$(module)))
 
 .PHONY: tfmodule/lint
 tfmodule/lint : tfmodule/init
 	@$(call check_terraform_fmt)
 	@$(foreach module,$(ALL_TF_MODULES),$(call tflint_terraform_module,$(module)))
 	@$(foreach module,$(ALL_TF_MODULES),$(call validate_terraform_module,$(module)))
+	@$(foreach module,$(ALL_EXAMPLES),$(call tflint_terraform_module,$(module)))
+	@$(foreach module,$(ALL_EXAMPLES),$(call validate_terraform_module,$(module)))
 
 .PHONY: tfmodule/list
 tfmodule/list :
@@ -114,15 +126,15 @@ tfmodule/list :
 
 .PHONY: tfmodule/plan
 tfmodule/plan : tfmodule/init
-	@$(foreach module,$(ALL_TF_MODULES),$(call plan_terraform_module,$(module)))
+	@$(foreach module,$(ALL_EXAMPLES),$(call plan_terraform_module,$(module)))
 
 .PHONY: tfmodule/test/regula
 tfmodule/test/regula : 
-	@$(foreach module,$(ALL_TF_MODULES),$(call regula_terraform_module,$(module)))
+	@$(foreach module,$(ALL_EXAMPLES),$(call regula_terraform_module,$(module)))
 
 .PHONY: tfmodule/test/conftest
 tfmodule/test/conftest : 
-	@$(foreach module,$(ALL_TF_MODULES),$(call conftest_terraform_module,$(module)))
+	@$(foreach module,$(ALL_EXAMPLES),$(call conftest_terraform_module,$(module)))
 
 .PHONY: tfmodule/pre_deploy_test
 tfmodule/pre_deploy_test : tfmodule/clone_custom_rules
@@ -143,10 +155,15 @@ else
 	git clone $(CUSTOM_POLICY_REPO) $(MODULE_DIR)/custom_policy
 endif
 
+.PHONY: tfmodule/create_example_providers
+tfmodule/create_example_providers:
+	@$(foreach example,$(ALL_EXAMPLES),$(call create_example_providers,$(example)))
+
 .PHONY: check
 check::
 	$(MAKE) tfmodule/lint
 	$(MAKE) tfmodule/clone_custom_rules
+	$(MAKE) tfmodule/create_example_providers
 	$(MAKE) tfmodule/plan
 	$(MAKE) tfmodule/test/conftest
 	$(MAKE) tfmodule/test/regula


### PR DESCRIPTION
Supersedes https://github.com/nexient-llc/lcaf-component-tf-module/pull/7.

Adds a dependency in the golang `make check` to init and plan modules prior to running tests, otherwise they will fail as the state file won't contain the outputs we're checking.

Instead of running plan/conftest/regula against the base TF module we'll run these steps against each example. The base module won't necessarily be deployable, since some variables could be required but unknowable at development time or require values filled in from other modules' outputs.

Initialization and linting will still be performed against the base module, in addition to also being performed against the examples.

As part of running `make check`, we will now lay down a provider.tf in each example module if not already present. This file is intentionally not checked into source control, as it could contain sensitive information like API keys. A minimal provider.tf is laid down for either AWS or Azure (depending on the name of the module) and environment variables are used to provide authentication.