### PR TITLE
Reformat Terraform files rather than just reporting

### DIFF
--- a/tasks/modules/Makefile
+++ b/tasks/modules/Makefile
@@ -24,8 +24,8 @@ CURRENT_DIR = $(notdir $(shell pwd))
 # Functions
 
 define check_terraform_fmt
-	echo && echo "Checking format ...";
-	$(TERRAFORM) fmt -recursive -check;
+	echo && echo "Formatting Terraform files ...";
+	$(TERRAFORM) fmt -recursive;
 
 endef
 


### PR DESCRIPTION
The `-check` flag makes `terraform fmt` exit with a nonzero code and emit the names of the files that are incorrectly formatted. This causes `make check` to fail as expected (since the repo is not in a desirable state) but ultimately creates a usability problem. It's important to know _where_ the problem file is, but not having an indication of _what_ is wrong with the file is a poor experience. A single missing (or extra) whitespace character is enough to cause a failure, which is especially frustrating when dealing with Terraform files that may be hundreds of lines long.

Going forward, removing the `-check` flag causes `terraform fmt` to automatically fix what can be fixed without disrupting `make check` if formatting issues can all be corrected.

If there are any Terraform files that are not syntactically valid, `terraform fmt` still exits with a nonzero exit code and causes `make check` to fail.