### PR TITLE
Sync components with the latest versions in .lcafenv at commit time

### DIFF
--- a/linkfiles/.pre-commit-config.yaml
+++ b/linkfiles/.pre-commit-config.yaml
@@ -1,4 +1,12 @@
 repos:
+  - repo: local
+    hooks:
+      - id: sync-launch-platform
+        name: sync-launch-platform
+        entry: bash -c 'make configure || rm -fr .repo components; make configure'
+        language: system
+        pass_filenames: false
+        always_run: true
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:


### PR DESCRIPTION
This ensures that changes to .lcafenv are picked up prior to running any further checks (linting, tests, etc.) during the commit phase.

If there's a dirty set of local repos for whatever reason (causes `make configure` to fail when calling `repo sync`), we'll bulldoze the .repo and components directories and force a full resync with `make configure`.

Note that this doesn't automatically bring a repo up to the latest available versions unless it's still tracking `main` in the manifest repo for some reason. If this is the case for your repo you'll want to adjust the REPO_BRANCH parameter to point at a specific tagged version rather than main to ensure a deterministic set of components.