### PR TITLE
Splits make check into two subtargets

### DIFF
--- a/tasks/golang/Makefile
+++ b/tasks/golang/Makefile
@@ -51,18 +51,13 @@ go/test :
 go/readonly_test:
 	$(foreach test_dir,$(GO_TEST_DIRECTORIES),$(call go_test,$(test_dir),$(TEST_RUN_ONLY_READONLY)))
 
-	
-
-# This is a special declaration
-# Whenever check is defined, it must be defined with a ::
-# _all_ check targets that are found will be run
-# https://www.gnu.org/software/make/manual/html_node/Double_002dColon.html
-# "check" is a GNU Make pattern that runs tests on configured software
-.PHONY: check
-check:: tfmodule/plan
+.PHONY: lint
+lint::
 ifeq ($(DISABLE_MAKE_CHECK_LINT),false)
 	$(MAKE) go/lint
 else
 	$(info "make go/lint has been disabled!")
-endif
+
+.PHONY: test
+test:: tfmodule/plan
 	$(MAKE) go/test

--- a/tasks/modules/Makefile
+++ b/tasks/modules/Makefile
@@ -105,7 +105,7 @@ endef
 # Tasks
 
 .PHONY: tfmodule/all
-tfmodule/all: check
+tfmodule/all: lint
 
 .PHONY: tfmodule/clean
 tfmodule/clean :
@@ -170,8 +170,8 @@ endif
 tfmodule/create_example_providers:
 	@$(foreach example,$(ALL_EXAMPLES),$(call create_example_providers,$(example)))
 
-.PHONY: check
-check::
+.PHONY: lint
+lint::
 	$(MAKE) tfmodule/lint
 	$(MAKE) tfmodule/clone_custom_rules
 	$(MAKE) tfmodule/create_example_providers


### PR DESCRIPTION
Splits `make check` into `make lint` and `make test`.

For Terraform actions, none of our existing targets run untrusted code, so these will end up part of `make lint`.

For golang actions, `golangci-lint` has been moved under `make lint` while `go test` has been moved under `make test` as it has the potential to execute untrusted code.

Will be tagged `0.4.0` upon merge.