### PR TITLE
Fix missing endif

### DIFF
--- a/tasks/golang/Makefile
+++ b/tasks/golang/Makefile
@@ -57,6 +57,7 @@ ifeq ($(DISABLE_MAKE_CHECK_LINT),false)
 	$(MAKE) go/lint
 else
 	$(info "make go/lint has been disabled!")
+endif
 
 .PHONY: test
 test:: tfmodule/plan


### PR DESCRIPTION
Since this hasn't been fully released, tag `0.4.0` will be repointed to the merge commit this PR generates.